### PR TITLE
Add Julia language definition

### DIFF
--- a/lang/julia.wsconf
+++ b/lang/julia.wsconf
@@ -1,0 +1,68 @@
+################################################################################
+#                                                                              #
+#      _                                                                _      #
+#    _(_)_                       Julia Files                          _(_)_    #
+#   (_) (_)                                                          (_) (_)   #
+#                                                                              #
+# by Alex Arslan (ararslan@comcast.net)                                        #
+################################################################################
+#                                                                              #
+# Indentation settings                                                         #
+*.jl
+    -ei 4
+    -ets
+#                                                                              #
+# Syntax highlighting                                                          #
+*.jl
+    -lcl #
+    -lcb #= =#
+    -lsc ' '
+    -lsm \"\"\" \"\"\"
+    -lsr \" \"
+    -lsr ` `
+    -les \\
+    -lb ( )
+    -lb [ ]
+    -lb { }
+#                                                                              #
+# Keywords                                                                     #
+*.jl
+    -lk abstract
+    -lk baremodule
+    -lk begin
+    -lk bitstype
+    -lk break
+    -lk catch
+    -lk const
+    -lk continue
+    -lk do
+    -lk else
+    -lk elseif
+    -lk end
+    -lk export
+    -lk finally
+    -lk for
+    -lk function
+    -lk global
+    -lk if
+    -lk immutable
+    -lk import
+    -lk importall
+    -lk in
+    -lk isa
+    -lk let
+    -lk local
+    -lk macro
+    -lk module
+    -lk mutable
+    -lk quote
+    -lk return
+    -lk struct
+    -lk try
+    -lk type
+    -lk typealias
+    -lk using
+    -lk where
+    -lk while
+#                                                                              #
+################################################################################


### PR DESCRIPTION
This PR adds a definition file for the [Julia language](http://julialang.org). It uses the Julia standard of 4 spaces for indentation. With this, the Julia files in Julia's standard library seem to be highlighted correctly.

The only issue is names that contain numbers: the numbers are highlighted within the name. For example, in the type `Int64`, `Int` will appear normally (i.e. not highlighted) but 64 is highlighted as a number. It's part of the identifier, so it would be nice if `Int64` (as just one of many examples) could be homogeneously colored. Is there a way I can specify that in the configuration file?

Oddly enough, despite the aforementioned issue, the unsigned literal`0x0000`, for example, has the leading 0 highlighted but not the trailing zeros.